### PR TITLE
Update gatsby-node.js

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,10 +10,10 @@ function onCreateWebpackConfig({ actions }) {
           exclude: /node_modules/,
           query: {
             src: [
-              "bower_components/purescript-*/src/**/*.purs",
               "src/**/*.purs"
             ],
-            pscIde: true
+            pscIde: true,
+            spago: true
           }
         }
       ]


### PR DESCRIPTION
Use spago instead of bower.

Update: It works! I'm very happy you made this because I didn't think it would be this easy. 
I just did:
```
spago init
```
In this pure JS Gatsby template and now I can import PS code!